### PR TITLE
fix(at_most_one_rule): Exclude empty lists from evaluated params, [] …

### DIFF
--- a/avtomat_aws/validations/rules.py
+++ b/avtomat_aws/validations/rules.py
@@ -45,7 +45,7 @@ def at_most_one_rule(kwargs, params):
     if len(params) < 2:
         raise ValueError("Rule 'at_most_one' requires at least two parameters")
 
-    params_defined = sum(kwargs.get(param) is not None for param in params)
+    params_defined = sum(kwargs.get(param) not in (None, []) for param in params)
     if params_defined > 1:
         raise ValueError(
             f"The following parameters cannot be used together, select only one: {params}"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other

## Current behavior
<!-- Describe the current behavior that you are modifying, or link to a relevant issue. -->
`at_most_one_rule` doesn't exclude empty lists when evaluating parameters and can raise `ValueError` if two or more parameters that cannot be used together have a default value of `[]`

## New behavior
<!-- Describe the new behavior after your code is merged. -->
`at_most_one_rule` now excludes empty lists when evaluating parameters

## Breaking change
<!-- If this PR introduces a breaking change, describe the impact and the changes users need to make in their application. -->
- [ ] Yes
- [x] No

### If yes, describe the breaking change

## Other information
<!-- Add any other context or screenshots about the feature request here. -->
