### PR TITLE
fix(authentication): Always call set_session and let the helper handl…

### DIFF
--- a/avtomat_aws/decorators/authenticate.py
+++ b/avtomat_aws/decorators/authenticate.py
@@ -7,11 +7,8 @@ def authenticate():
 
     def decorator(func):
         def wrapper(**kwargs):
-            # Check if session is not provided and create one if necessary
-            if not kwargs.get("session"):
-                kwargs["session"] = set_session(
-                    debug=kwargs.get("debug"), silent=kwargs.get("silent")
-                )
+            # Create a session
+            kwargs["session"] = set_session(**kwargs)
             # Set the region for the session
             kwargs["region"] = set_region(
                 region=kwargs.get("region"),

--- a/avtomat_aws/helpers/set_session.py
+++ b/avtomat_aws/helpers/set_session.py
@@ -14,7 +14,10 @@ def set_session(**kwargs):
     if kwargs.get("silent"):
         logger.setLevel(logging.WARNING)
 
-    if kwargs.get("profile"):
+    if kwargs.get("session"):
+        logger.debug("Session explicitly supplied.")
+        session = kwargs["session"]
+    elif kwargs.get("profile"):
         session = authenticate_profile(kwargs["profile"])
     elif kwargs.get("role_arn"):
         session = authenticate_role(
@@ -26,7 +29,7 @@ def set_session(**kwargs):
         )
     else:
         logger.debug(
-            "No 'profile' or 'role_arn' or 'access_key' + 'secret_key' parameters supplied. "
+            "No 'session' or 'profile' or 'role_arn' or 'access_key' + 'secret_key' parameters supplied. "
             "Falling back to default credentials."
         )
         session = authenticate_default()


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other

## Current behavior
The `authenticate` decorator doesn't invoke `set_session` helper if a session has been explicitly supplied

## New behavior
The decorator now always invokes `set_session`. The helper decides if a new session should be created or if it already exists.

## Breaking change
<!-- If this PR introduces a breaking change, describe the impact and the changes users need to make in their application. -->
- [ ] Yes
- [x] No

### If yes, describe the breaking change

## Other information
<!-- Add any other context or screenshots about the feature request here. -->
