### PR TITLE
fix(validation-logic): Fix cloudtrail validation logic to correctly e…

### DIFF
--- a/avtomat_aws/services/cloudtrail/discover_events.py
+++ b/avtomat_aws/services/cloudtrail/discover_events.py
@@ -9,8 +9,8 @@ from avtomat_aws.helpers.set_session_objects import set_session_objects
 logger = logging.getLogger(__name__)
 
 DEFAULTS = {
-    "created_after": (datetime.now() - timedelta(days=90)).strftime("%Y/%m/%d"),
-    "created_before": (datetime.now()).strftime("%Y/%m/%d"),
+    "created_after": datetime.now() - timedelta(days=90),
+    "created_before": datetime.now(),
     "region": None,
     "debug": False,
     "silent": False,
@@ -31,12 +31,11 @@ def discover_events(**kwargs):
     # Required parameters
     event = kwargs.pop("event")
 
-    if kwargs.get("created_after"):
+    if kwargs.get("created_after") and type(kwargs["created_after"]) is str:
         kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
-    if kwargs.get("created_before"):
+    if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
-            kwargs["created_before"], "%Y/%m/%d"
-        )
+            kwargs["created_before"], "%Y/%m/%d")
 
     logger.info(f"Discovering CloudTrail events for '{event}'")
 

--- a/avtomat_aws/services/cloudtrail/discover_events.py
+++ b/avtomat_aws/services/cloudtrail/discover_events.py
@@ -35,7 +35,8 @@ def discover_events(**kwargs):
         kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
     if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
-            kwargs["created_before"], "%Y/%m/%d")
+            kwargs["created_before"], "%Y/%m/%d"
+        )
 
     logger.info(f"Discovering CloudTrail events for '{event}'")
 

--- a/avtomat_aws/services/cloudtrail/discover_resource_events.py
+++ b/avtomat_aws/services/cloudtrail/discover_resource_events.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULTS = {
     "events": [],
-    "created_after": (datetime.now() - timedelta(days=90)).strftime("%Y/%m/%d"),
-    "created_before": (datetime.now()).strftime("%Y/%m/%d"),
+    "created_after": datetime.now() - timedelta(days=90),
+    "created_before": datetime.now(),
     "region": None,
     "debug": False,
     "silent": False,
@@ -32,12 +32,11 @@ def discover_resource_events(**kwargs):
     # Required parameters
     resource_id = kwargs.pop("resource_id")
 
-    if kwargs.get("created_after"):
+    if kwargs.get("created_after") and type(kwargs["created_after"]) is str:
         kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
-    if kwargs.get("created_before"):
+    if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
-            kwargs["created_before"], "%Y/%m/%d"
-        )
+            kwargs["created_before"], "%Y/%m/%d")
 
     logger.info(f"Discovering CloudTrail events for resource '{resource_id}'")
 

--- a/avtomat_aws/services/cloudtrail/discover_resource_events.py
+++ b/avtomat_aws/services/cloudtrail/discover_resource_events.py
@@ -36,7 +36,8 @@ def discover_resource_events(**kwargs):
         kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
     if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
-            kwargs["created_before"], "%Y/%m/%d")
+            kwargs["created_before"], "%Y/%m/%d"
+        )
 
     logger.info(f"Discovering CloudTrail events for resource '{resource_id}'")
 

--- a/avtomat_aws/services/cloudtrail/discover_user_events.py
+++ b/avtomat_aws/services/cloudtrail/discover_user_events.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULTS = {
     "events": [],
-    "created_after": (datetime.now() - timedelta(days=90)).strftime("%Y/%m/%d"),
-    "created_before": (datetime.now()).strftime("%Y/%m/%d"),
+    "created_after": datetime.now() - timedelta(days=90),
+    "created_before": datetime.now(),
     "region": None,
     "debug": False,
     "silent": False,
@@ -32,12 +32,11 @@ def discover_user_events(**kwargs):
     # Required parameters
     user = kwargs.pop("user")
 
-    if kwargs.get("created_after"):
+    if kwargs.get("created_after") and type(kwargs["created_after"]) is str:
         kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
-    if kwargs.get("created_before"):
+    if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
-            kwargs["created_before"], "%Y/%m/%d"
-        )
+            kwargs["created_before"], "%Y/%m/%d")
 
     logger.info(f"Discovering CloudTrail events for user '{user}'")
 

--- a/avtomat_aws/services/cloudtrail/discover_user_events.py
+++ b/avtomat_aws/services/cloudtrail/discover_user_events.py
@@ -36,7 +36,8 @@ def discover_user_events(**kwargs):
         kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
     if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
-            kwargs["created_before"], "%Y/%m/%d")
+            kwargs["created_before"], "%Y/%m/%d"
+        )
 
     logger.info(f"Discovering CloudTrail events for user '{user}'")
 

--- a/avtomat_aws/services/ec2/discover_images.py
+++ b/avtomat_aws/services/ec2/discover_images.py
@@ -27,12 +27,12 @@ RULES = [{"date_yymmdd": ["created_before", "created_after"]}]
 def discover_images(**kwargs):
     """Discover images based on provided criteria"""
 
-    if kwargs.get("created_before"):
+    if kwargs.get("created_after") and type(kwargs["created_after"]) is str:
+        kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
+    if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
             kwargs["created_before"], "%Y/%m/%d"
         )
-    if kwargs.get("created_after"):
-        kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
 
     logger.info("Discovering images")
 

--- a/avtomat_aws/services/ec2/discover_snapshots.py
+++ b/avtomat_aws/services/ec2/discover_snapshots.py
@@ -31,12 +31,12 @@ RULES = [
 def discover_snapshots(**kwargs):
     """Discover snapshots based on provided criteria"""
 
-    if kwargs.get("created_before"):
+    if kwargs.get("created_after") and type(kwargs["created_after"]) is str:
+        kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
+    if kwargs.get("created_before") and type(kwargs["created_before"]) is str:
         kwargs["created_before"] = datetime.strptime(
             kwargs["created_before"], "%Y/%m/%d"
         )
-    if kwargs.get("created_after"):
-        kwargs["created_after"] = datetime.strptime(kwargs["created_after"], "%Y/%m/%d")
 
     logger.info("Discovering snapshots")
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other

## Current behavior
<!-- Describe the current behavior that you are modifying, or link to a relevant issue. -->
1. `cloudtrail_rule` validation doesn't make a difference between a `string` and a `datetime` object when processing dates
2. `at_most_one_rule` validation incorrectly includes `False` boolean parameters. This is a default value if the parameter is not supplied.
3. `ec2.discover_images` - action doesn't make a difference between a `string` and a `datetime` object when processing dates
4. `ec2.discover_snapshots` - action doesn't make a difference between a `string` and a `datetime` object when processing dates

## New behavior
<!-- Describe the new behavior after your code is merged. -->
1. The validation now handles both types correctly
2. The validation now excludes `False` values
3. The validation now handles both types correctly
4. The validation now handles both types correctly

## Breaking change
<!-- If this PR introduces a breaking change, describe the impact and the changes users need to make in their application. -->
- [ ] Yes
- [x] No

### If yes, describe the breaking change

## Other information
<!-- Add any other context or screenshots about the feature request here. -->
