### PR TITLE
fix(ec2.delete_instances): Add 'disable_protections' parameter allowi…

### DIFF
--- a/avtomat_aws/cli/ec2/delete_instances.py
+++ b/avtomat_aws/cli/ec2/delete_instances.py
@@ -1,7 +1,9 @@
 from avtomat_aws.helpers.cli.set_output import set_output
 from avtomat_aws.services.ec2 import delete_instances
 
-ACTION_DESCRIPTION = "Delete EC2 instances."
+ACTION_DESCRIPTION = (
+    "Delete EC2 instances and, optionally, any associated resource types."
+)
 
 
 def add_cli_arguments(parser):
@@ -25,6 +27,12 @@ def add_cli_arguments(parser):
         "--final_image",
         action="store_true",
         help="Create an image (AMI) before deletion.",
+        required=False,
+    )
+    parser.add_argument(
+        "--disable_protections",
+        action="store_true",
+        help="Disable termination and stop protection before deletion.",
         required=False,
     )
 


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [x] Other

## Current behavior
<!-- Describe the current behavior that you are modifying, or link to a relevant issue. -->
`ec2.delete_instances` doesn't have the capability to disable termination and stop API protections before attempting deletion.

## New behavior
<!-- Describe the new behavior after your code is merged. -->
The action now has a new parameter, `disable_protections`, which allows for disabling of termination and stop API protections before attempting deletion.

## Breaking change
<!-- If this PR introduces a breaking change, describe the impact and the changes users need to make in their application. -->
- [ ] Yes
- [x] No

### If yes, describe the breaking change

## Other information
<!-- Add any other context or screenshots about the feature request here. -->
