### PR TITLE
fix(ec2.delete_instances.discover_image_snapshots): Skip snapshot ret…

### DIFF
--- a/avtomat_aws/cli/ec2/delete_instances.py
+++ b/avtomat_aws/cli/ec2/delete_instances.py
@@ -42,9 +42,9 @@ def cli(args):
 
     inputs = vars(args)
 
-    try:
-        result = delete_instances(**inputs)
-        set_output(result, inputs)
-    except Exception as e:
-        print(f"Action failed - {e}")
-        exit(1)
+    # try:
+    result = delete_instances(**inputs)
+    set_output(result, inputs)
+    # except Exception as e:
+    #    print(f"Action failed - {e}")
+    #    exit(1)

--- a/avtomat_aws/cli/ec2/delete_instances.py
+++ b/avtomat_aws/cli/ec2/delete_instances.py
@@ -42,9 +42,9 @@ def cli(args):
 
     inputs = vars(args)
 
-    # try:
-    result = delete_instances(**inputs)
-    set_output(result, inputs)
-    # except Exception as e:
-    #    print(f"Action failed - {e}")
-    #    exit(1)
+    try:
+        result = delete_instances(**inputs)
+        set_output(result, inputs)
+    except Exception as e:
+        print(f"Action failed - {e}")
+        exit(1)


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other

## Current behavior
<!-- Describe the current behavior that you are modifying, or link to a relevant issue. -->
`ec2.delete_instances.discover_image_snapshots` produces an error when attempting to discover snapshots associated with an image which has not yet reached `available` state

## New behavior
<!-- Describe the new behavior after your code is merged. -->
The function now will now skip snapshot retrieval for associated images that are not in `available` state and log a warning

## Breaking change
<!-- If this PR introduces a breaking change, describe the impact and the changes users need to make in their application. -->
- [ ] Yes
- [x] No

### If yes, describe the breaking change

## Other information
<!-- Add any other context or screenshots about the feature request here. -->
